### PR TITLE
fix: facebook meta key

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -6,7 +6,7 @@ import { camelcase, toAttrs } from './utils.ts';
 export const transform = (options: Options): HtmlTagDescriptor[] => {
   const basicOGMetaAttrs = Object.entries(options.basic || {}).map(([name, content]) => toAttrs(camelcase(name), content, 'property', 'og'));
   const twitterOGMetaAttrs = Object.entries(options.twitter || {}).map(([name, content]) => toAttrs(camelcase(name), content, 'name', 'twitter'));
-  const facebookOGMetaAttrs = Object.entries(options.facebook || {}).map(([name, content]) => toAttrs(camelcase(name), content, 'name', 'fb'));
+  const facebookOGMetaAttrs = Object.entries(options.facebook || {}).map(([name, content]) => toAttrs(camelcase(name), content, 'property', 'fb'));
 
   const attrs = [...basicOGMetaAttrs.flat(), ...twitterOGMetaAttrs.flat(3), ...facebookOGMetaAttrs.flat()];
 


### PR DESCRIPTION
use `name` instead of `property`.
fixed #16